### PR TITLE
Updated `transformers` version and updated import path

### DIFF
--- a/lavila/models/narrator.py
+++ b/lavila/models/narrator.py
@@ -14,9 +14,13 @@ from torch import nn
 import torch.nn.functional as F
 from einops import rearrange, repeat
 from transformers import BeamSearchScorer
-from transformers.generation_logits_process import (
-    LogitsProcessorList, TopKLogitsWarper, TopPLogitsWarper,
-    TemperatureLogitsWarper, TypicalLogitsWarper, LogitNormalization
+from transformers.generation.logits_process import (
+    LogitsProcessorList,
+    TopKLogitsWarper,
+    TopPLogitsWarper,
+    TemperatureLogitsWarper,
+    TypicalLogitsWarper,
+    LogitNormalization,
 )
 
 from lavila.models.coca import CrossAttention, LayerNorm

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ decord==0.6.0
 einops==0.4.1
 pandas==1.4.2
 pytorchvideo==0.1.5
-transformers==4.21
+transformers==4.27
 ftfy==4.4.3
 spacy==3.4.1
 scikit-learn==1.1.1


### PR DESCRIPTION
The `transformers` version listed in `requirements.txt` is a bit too old to load newer models from HuggingFace, which this PR fixes. From `transformers>=4.25`, `transformer.generation_logits_process` was moved to `transformer.generation.logits_process`. 