### PR TITLE
helper script to convert egovlp checkpoint

### DIFF
--- a/scripts/convert_egovlp_ckpt.py
+++ b/scripts/convert_egovlp_ckpt.py
@@ -1,0 +1,51 @@
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+'''
+Usage:
+```bash
+PYTHONPATH=<EgoVLP-ROOT> python scripts/convert_egovlp_ckpt.py \
+    --input-ckpt <EGOVLP_PATH> \
+    --output-ckpt egovlp_converted.pth
+```
+'''
+
+import argparse
+from collections import OrderedDict
+import torch
+
+
+def get_args_parser():
+    parser = argparse.ArgumentParser(description='Convert EgoVLP checkpoint', add_help=False)
+    parser.add_argument('--input-ckpt', type=str)
+    parser.add_argument('--output-ckpt', type=str)
+    return parser
+
+
+def main(args):
+    input_ckpt = torch.load(args.input_ckpt, map_location='cpu')
+    input_ckpt = input_ckpt['state_dict']
+    output_ckpt = OrderedDict()
+    for k in input_ckpt:
+        if k.startswith('module.video_model'):
+            output_ckpt[k.replace('module.video_model', 'module.visual')] = input_ckpt[k]
+        elif k.startswith('module.text_model'):
+            output_ckpt[k.replace('module.text_model', 'module.textual')] = input_ckpt[k]
+        elif k.startswith('module.txt_proj'):
+            output_ckpt[k.replace('module.txt_proj', 'module.text_projection')] = input_ckpt[k]
+        elif k.startswith('module.vid_proj'):
+            output_ckpt[k.replace('module.vid_proj', 'module.image_projection')] = input_ckpt[k]
+        else:
+            print(k)
+            raise ValueError
+    torch.save({
+        'epoch': 0,
+        'state_dict': output_ckpt,
+        'best_acc1': 0,
+        }, args.output_ckpt)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser('Convert EgoVLP checkpoint', parents=[get_args_parser()])
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
Usage:
First, run:
```bash
# Need to explicitly export PYTHONPATH=<EgoVLP_ROOT> to go through its parser
PYTHONPATH=<EgoVLP_ROOT> python scripts/convert_egovlp_ckpt.py \
    --input-ckpt <EGOVLP_PATH> \
    --output-ckpt egovlp_converted.pth
```

Next, attach args information to the checkpoint by running the pre-training script:
```bash
PYTHONPATH=. torchrun --nproc_per_node=8 main_pretrain.py \
    --clip-length 16 --clip-stride 4 \
    --model CLIP_HF_EGOVLP_DISTILBERT_BASE \
    --resume ./egovlp_converted.pth \
    --output-dir <EXP_DIR>
```
Note that you don't need to run the entire pre-training. Simply modify the [main_pretrain.py](https://github.com/facebookresearch/LaViLa/blob/main/main_pretrain.py) by adding `dist_utils.save_on_master()` at the very beginning of the training loop and exiting early. The saved checkpoint will have the same format as the exported one at [MODEL_ZOO.md#zero-shot](https://github.com/facebookresearch/LaViLa/blob/main/docs/MODEL_ZOO.md#zero-shot). You can use it for zero-shot evaluation (compatible with [eval_zeroshot.py](https://github.com/facebookresearch/LaViLa/blob/main/eval_zeroshot.py)).
